### PR TITLE
Time: Assume milliseconds timestamp

### DIFF
--- a/src/scripts/time.ts
+++ b/src/scripts/time.ts
@@ -1,6 +1,11 @@
 import { IScript, ISwissKnifeContext } from "../Interfaces";
 
 export const toTimestamp = async (text: string): Promise<string> => {
+  /* If timestamp is superior to the year 2969, let’s assume it is a milliseconds timestamp */
+  let intText = parseInt(text);
+  if (intText == text && intText > 31536000000) {
+    text = parseInt(text) / 1000;
+  }
   return (new Date(text).getTime() / 1000).toString();
 };
 

--- a/src/scripts/time.ts
+++ b/src/scripts/time.ts
@@ -4,7 +4,7 @@ export const toTimestamp = async (text: string): Promise<string> => {
   /* If timestamp is superior to the year 2969, let’s assume it is a milliseconds timestamp */
   let intText = parseInt(text);
   if (intText == text && intText > 31536000000) {
-    text = parseInt(text) / 1000;
+    text = intText / 1000;
   }
   return (new Date(text).getTime() / 1000).toString();
 };

--- a/src/scripts/time.ts
+++ b/src/scripts/time.ts
@@ -1,16 +1,15 @@
 import { IScript, ISwissKnifeContext } from "../Interfaces";
 
 export const toTimestamp = async (text: string): Promise<string> => {
-  /* If timestamp is superior to the year 2969, let’s assume it is a milliseconds timestamp */
-  let intText = parseInt(text);
-  if (intText == text && intText > 31536000000) {
-    text = intText / 1000;
-  }
   return (new Date(text).getTime() / 1000).toString();
 };
 
 export const fromTimestamp = async (text: string): Promise<string> => {
-  return new Date(parseInt(text) * 1000).toUTCString();
+  /* If timestamp is superior to the year 2969, let’s assume it is a milliseconds timestamp */
+  let intText = parseInt(text);
+  intText = intText > 31536000000 ?  intText : intText * 1000;
+
+  return new Date(parseInt(intText) * 1000).toUTCString();
 };
 
 


### PR DESCRIPTION
If timestamp is superior to the year 2969, let’s assume it is a milliseconds timestamp